### PR TITLE
kubernetes-intro ready

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: koreshz/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: koreshz/hw:v1.1
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init-web
+    image: busybox:1.31.0
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx
+
+COPY default.conf /etc/nginx/conf.d/default.conf 
+
+ARG nginx_uid=1001
+ARG nginx_gid=1001
+
+RUN usermod -u $nginx_uid nginx && groupmod -g $nginx_gid nginx
+

--- a/kubernetes-intro/web/default.conf
+++ b/kubernetes-intro/web/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       8000;
+    listen  [::]:8000;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    #error_page   500 502 503 504  /50x.html;
+    #location = /50x.html {
+    #    root   /app;
+    #}
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе выполнено:
 - Создан и загружен на docker hub образ контейнера веб сервера на основе nxinx
 - Разработан манифест для запуска пода состоящего из веб сервера и получающего наполнение через initContainer
 - Для передачи данных между основным контейнером и init контейнером использована emptyDir

## Как запустить проект:
 - Для создания образа docker контейна под нужную архитектуру использовать команду `docker buildx build --push --platform linux/amd64 --tag koreshz/hw:v1.1 web`
 - Для запуска манифеста использовать `kubectl apply -f <manifest.yaml>`

## Как проверить работоспособность:
 - Для проброса порта из кластера использовать `kubectl port-forward web 8000`
 - Перейти по ссылке http://localhost:8000

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
